### PR TITLE
Return failed promise on FormFor#doSubmit fail

### DIFF
--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -346,6 +346,7 @@ const FormFor = Ember.Component.extend({
         .catch(_ => {
           this.notifyError(this.get('failed-submit-message'));
           this.failedSubmit(_);
+          return Promise.reject(_);
         })
         .finally(() => this.set('isSubmitting', false));
     }


### PR DESCRIPTION
Allows the promise to be chainable