### PR TITLE
Fix issue when using deconst setProps has different outcome on models.

### DIFF
--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -497,7 +497,7 @@ const FieldFor = Ember.Component.extend({
       form.resetValue(this.get('params')[0], this.get('_lastValidValue'));
     }
 
-    form.runValidations();
+    form.clearValidations();
   },
 
   actions: {

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -272,6 +272,16 @@ const FormFor = Ember.Component.extend({
   },
 
   /**
+   * Clears the validations on the model
+   * @method clearValidations
+   * @public
+   */
+  clearValidations() {
+    const model = this.get('model');
+    return model.validate && model.validate({ only: [] });
+  },
+
+  /**
    * Called before the form submits, this is where we do
    * validation
    * @method willSubmit
@@ -506,7 +516,13 @@ const FormFor = Ember.Component.extend({
   updateValues(keyValues) {
     this._checkClean();
 
-    setProperties(this.get('model'), keyValues);
+    const model = this.get('model');
+    
+    if (model.setProperties) {
+      model.setProperties(keyValues);
+    } else { 
+     setProperties(model, keyValues);
+    }
 
     if (this.get('_hasFailedToSubmit')) {
       Ember.run.next(() => this.runValidations());
@@ -531,7 +547,14 @@ const FormFor = Ember.Component.extend({
   },
 
   resetValues(keyValues) {
-    setProperties(this.get('model'), keyValues);
+    const model = this.get('model');
+    
+    if (model.setProperties) {
+      model.setProperties(keyValues);
+    } else {
+      setProperties(model, keyValues);
+    }
+    
     this._checkClean();
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-foxy-forms",
-  "version": "1.0.0-pre46",
+  "version": "1.0.0-pre47",
   "description": "An addon for building forms that work with ember data",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
* For whatever reason, using Ember.setProperties on a model has unexpected consequences when dealing with dates, seems to mark the same date object as a changedAttribute
* Also, since the purpose of running validations after a field reset was to reset the errors, I've added a `clearValidations`, which clears the validations without having to run them.