### PR TITLE
Fix typo in usage Doc

### DIFF
--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage 
 
-Below is a configurable example of the basic usage of ember-foxy-forms, it showcases all of the htm5 input controls
+Below is a configurable example of the basic usage of ember-foxy-forms, it showcases all of the html5 input controls
 that can be mounted to your data model.
 
 The various features can be toggled on / off below.


### PR DESCRIPTION
Just a small typo fix. htm5 -> html5

Cool project! Just reading through the docs now 👍 