### PR TITLE
Enhance using to allow for custom lookup

### DIFF
--- a/addon/services/form-for.js
+++ b/addon/services/form-for.js
@@ -24,8 +24,6 @@ export default class FormForService extends Service {
     this.destroyButtonClasses = this.config.destroyButtonClasses;
     this.customCommitCancelComponent = this.config.customCommitCancelComponent;
     this.customErrorComponent = this.config.customErrorComponent;
-    this.controlPrefix = this.config.controlPrefix;
-    this.controlsFolder = this.config.controlsFolder;
 
     this.router.on('routeWillChange', (transition) => {
       if (

--- a/tests/dummy/app/templates/docs/controls.md
+++ b/tests/dummy/app/templates/docs/controls.md
@@ -155,8 +155,8 @@ we have built are:
 - Rich Text editor
 - JSON editor
 
-By default Foxy Forms looks for your custom controls in the component directory form-controls, but you can also specify the
-full path to the control.
+By default Foxy Forms looks for your custom controls in the component directory form-controls of your application, 
+but you can also specify the full path to the control.
 
 {{#docs-demo as |demo|}}
   {{#demo.example name="custom-controls-usage.hbs"}}

--- a/tests/dummy/app/templates/docs/fields.md
+++ b/tests/dummy/app/templates/docs/fields.md
@@ -17,6 +17,24 @@ controlling a date range. This can be done by simply passing an array of keys to
   {{demo.snippet "multiple.hbs"}}
 {{/docs-demo}}
 
+## Specifying the control
+
+FieldFor accepts a @using parameter, which instructs it to use a particular form control for the field. It uses the following
+rubric to lookup your component based on that name.FieldFor
+
+1. It looks for a custom control in your application with a path matching ```form-controls/<@using>```
+2. It looks for a custom control in your application with a path matching ```form-controls/<@using>-control``` this affordance is for legacy projects and will be removed in version 3.0.0
+3. It looks for a pre-packaged control in foxy-forms with a path matching ```form-controls/ff-<@using>```
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="using.hbs"}}
+    <Form @for={{this.object}} @preventsNavigation={{false}}  as |f|>
+      <f.field @for='labeledAttribute' @using='input' />
+    </Form> 
+  {{/demo.example}}
+  {{demo.snippet "using.hbs"}}
+{{/docs-demo}}
+
 ## Labels
 
 FieldFor has the option to label controls, if you provide a label, field for will automatically wire the label's 'for' 


### PR DESCRIPTION
This commit adds the ability to pass a name to the @using parameter
which will make the field component lookup your custom component in one
of three places:

1) In your project form-controls/<name>, this is the correct way to
import a custom component
2) In your project form-controls/<name>-control, this method will be
deprecated, but is in place to support the old implementation
3) In foxy-forms form-controls/ff-<name> this is the location of the
default packaged form controls.