### PR TITLE
Allow for inversion of checkboxes

### DIFF
--- a/addon/components/form-controls/ff-checkbox.hbs
+++ b/addon/components/form-controls/ff-checkbox.hbs
@@ -9,7 +9,7 @@
     value="true"
     type="checkbox"
     id="{{this.id}}"
-    checked={{@value}}
+    checked={{this.checked}}
     disabled={{@disabled}}
     data-test-ff-control-checkbox
   />

--- a/addon/components/form-controls/ff-checkbox.js
+++ b/addon/components/form-controls/ff-checkbox.js
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { arg } from 'ember-arg-types';
+import { bool } from 'prop-types';
 
 export default class FormControlsFfCheckboxComponent extends Component {
+  @arg value = false;
+  @arg(bool) isInverted = false;
+
   get id() {
     return guidFor(this);
+  }
+
+  get checked() {
+    return this.isInverted ? !this.value : this.value;
   }
 
   @action


### PR DESCRIPTION
This commit lets checkboxes be inverted, there are times where you might
want checking a checkbox to have the opposite effect on the underlying
model. Which is to say render selected when its value is absent.