### PR TITLE
Allow for inverting checkbox selection

### DIFF
--- a/addon/components/form-controls/ff-checkbox-select.hbs
+++ b/addon/components/form-controls/ff-checkbox-select.hbs
@@ -26,6 +26,7 @@
             checked={{compute this.isSelected value}}
             disabled={{@disabled}}
             data-test-ff-control-checkbox-select-input={{index}}
+            data-test-index="{{index}}"
           />
 
           {{#if (has-block)}}

--- a/addon/components/form-controls/ff-checkbox-select.js
+++ b/addon/components/form-controls/ff-checkbox-select.js
@@ -11,6 +11,9 @@ export default class FormControlsFfCheckboxSelectComponent extends FormControlsA
   @arg(string)
   for = 'id';
 
+  @arg(bool)
+  isInverted = false;
+
   @arg(number)
   selectionMax;
 
@@ -52,7 +55,8 @@ export default class FormControlsFfCheckboxSelectComponent extends FormControlsA
 
   @action
   isSelected(value) {
-    return !!this.value.find((_) => this._compare(_, value));
+    const isSelected = !!this.value.find((_) => this._compare(_, value));
+    return this.isInverted ? !isSelected : isSelected;
   }
 
   @action


### PR DESCRIPTION
This commit allows for the inversion of checkbox selection, useful for
making block lists etc.

It also adds a data test index to the checkbox select.