### PR TITLE
Ensure abstract select makes proper comparison

### DIFF
--- a/addon/components/form-controls/abstract-select.js
+++ b/addon/components/form-controls/abstract-select.js
@@ -39,7 +39,19 @@ export default class FormControlsAbstractSelectComponent extends Component {
     return this._isPrimitive(item) ? item : get(item, this.labelKey);
   }
 
+  /**
+   * Coerces the value to lowest possible identity, useful for comparison
+   * @param {*} value
+   */
   coerceValue(value) {
+    return this._isPrimitive(value) ? value : get(value, this.idKey);
+  }
+
+  /**
+   * Returns the value as it's supposed to be stored
+   * @param {*} value
+   */
+  storeValue(value) {
     if (this._isPrimitive(value)) {
       return value;
     }

--- a/addon/components/form-controls/ff-checkbox-select.js
+++ b/addon/components/form-controls/ff-checkbox-select.js
@@ -61,7 +61,7 @@ export default class FormControlsFfCheckboxSelectComponent extends FormControlsA
   }
 
   add(value) {
-    this.args.onChange(A(this.value).toArray().concat(this.coerceValue(value)));
+    this.args.onChange(A(this.value).toArray().concat(this.storeValue(value)));
   }
 
   @action

--- a/addon/components/form-controls/ff-select.js
+++ b/addon/components/form-controls/ff-select.js
@@ -18,7 +18,7 @@ export default class FormControlsFfSelectComponent extends FormControlsAbstractS
     value = this.values.find((_) => this._compare(_, value));
 
     if (this.args.onChange) {
-      return this.args.onChange(this.coerceValue(value));
+      return this.args.onChange(this.storeValue(value));
     }
   }
 }


### PR DESCRIPTION
* Further reduces responsibility of `coerceValue` method in abstract select to ensure that it's sole responibility is to reduce an object to it's lowest possible form for potential comparisons
* Seperates the responsibility of coercing the value into it's `store` value by providing a `storeValue` method