### PR TITLE
Add support for `displayValue` override in `field-for`

### DIFF
--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -142,6 +142,7 @@ export default class FieldForComponent extends Component {
    * @default value
    * @private
    */
+  @arg(string)
   get displayValue() {
     return this.formatValue(this.value);
   }


### PR DESCRIPTION
Adds support for overriding the `displayValue` of `field-for` from above.