### PR TITLE
Fix fieldClass passdown and minor fixes

### DIFF
--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -11,7 +11,7 @@ import { guidFor } from '@ember/object/internals';
 import { later } from '@ember/runloop';
 import { isBlank } from '@ember/utils';
 import { inject as service } from '@ember/service';
-import { debug } from '@ember/debug';
+import { deprecate } from '@ember/debug';
 import { getOwner } from '@ember/application';
 
 export default class FieldForComponent extends Component {
@@ -497,11 +497,8 @@ export default class FieldForComponent extends Component {
 
     if (lookup.componentFor(`form-controls/${name}`, owner)) {
       return `form-controls/${name}`;
-    } else if (lookup.componentFor(`form-controls/${this.name}-control`, owner)) {
-      debug.deprecate(
-        'This method of looking up form controls will be removed in version 3.0.0',
-        true
-      );
+    } else if (lookup.componentFor(`form-controls/${name}-control`, owner)) {
+      deprecate('This method of looking up form controls will be removed in version 3.0.0', true);
 
       return `form-controls/${name}-control`;
     } else if (lookup.componentFor(`form-controls/ff-${name}`, owner)) {

--- a/addon/components/form-for.hbs
+++ b/addon/components/form-for.hbs
@@ -27,6 +27,7 @@
           testingClassPrefix=this.testingClassPrefix
           hasControlCallout=this.hasControlCallout
           fieldForControlCalloutClasses=this.fieldForControlCalloutClasses
+          fieldClasses=this.fieldClasses
         )
         fieldFor=(component
           "field-for"
@@ -41,6 +42,7 @@
           testingClassPrefix=this.testingClassPrefix
           hasControlCallout=this.hasControlCallout
           fieldForControlCalloutClasses=this.fieldForControlCalloutClasses
+          fieldClasses=this.fieldClasses
         )
         button=(component
           this.buttonComponent

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -397,7 +397,9 @@ export default class FormForComponent extends Component {
    * @public
    */
   @arg(bool)
-  preventsNavigation = true;
+  get preventsNavigation() {
+    return this.formFor.preventsNavigationByDefault ?? false;
+  }
 
   /**
    * Parent form. Used to connect nested form state. Currently used to propagate dirty state to parent.

--- a/addon/services/form-for.js
+++ b/addon/services/form-for.js
@@ -25,6 +25,7 @@ export default class FormForService extends Service {
     this.customCommitCancelComponent = this.config.customCommitCancelComponent;
     this.customErrorComponent = this.config.customErrorComponent;
     this.customButtonComponent = this.config.customButtonComponent;
+    this.preventsNavigationByDefault = this.config.preventsNavigationByDefault;
 
     this.router.on('routeWillChange', (transition) => {
       if (


### PR DESCRIPTION
* Ensures fieldClass get's passed to `field-for` component
* Fixes issue where form controls in the old style couldn't be found because of a syntax error
* Defaults preventsNavigation to false, but allows for a configuration to have it set to true by default