### PR TITLE
Prevent .toJSON from being called on ember-models

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "faker": "^5.1.0",
+    "is-plain-object": "^5.0.0",
     "loader.js": "^4.7.0",
     "minimatch": "^3.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
* Since .toJSON on Ember Models is deprecated blindly serializing them to check for identity needed to be revised
* Added a check for whether or not an object is a not POJO as a way to optionally map an object to a unique identifier
* All POJOs and primatives will be serialized as before