### PR TITLE
Move is-plain-object into main dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "ember-cli-htmlbars": "^5.3.1",
         "ember-composable-helpers": "^4.3.0",
         "ember-element-helper": "^0.3.1",
-        "ember-event-helpers": "^0.1.1"
+        "ember-event-helpers": "^0.1.1",
+        "is-plain-object": "^5.0.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
@@ -58,7 +59,6 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.1.4",
         "faker": "^5.1.0",
-        "is-plain-object": "^5.0.0",
         "loader.js": "^4.7.0",
         "minimatch": "^3.0.4",
         "npm-run-all": "^4.1.5",
@@ -21511,7 +21511,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -44883,6 +44882,7 @@
     },
     "esdoc": {
       "version": "git+ssh://git@github.com/pzuraq/esdoc.git#015a3426b2e53b2b0270a9c00133780db3f1d144",
+      "integrity": "sha512-EajXz0w9voTcv6P3VlTZ06M8qKXTmT6Gw4EPLSmhML/MF8u4nH0/nIpKlbb776QkBl3r5/u0VX3Avk7BpUHQbQ==",
       "dev": true,
       "from": "esdoc@github:pzuraq/esdoc#015a342",
       "requires": {
@@ -47968,8 +47968,7 @@
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "ember-cli-htmlbars": "^5.3.1",
     "ember-composable-helpers": "^4.3.0",
     "ember-element-helper": "^0.3.1",
-    "ember-event-helpers": "^0.1.1"
+    "ember-event-helpers": "^0.1.1",
+    "is-plain-object": "^5.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
@@ -76,7 +77,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "faker": "^5.1.0",
-    "is-plain-object": "^5.0.0",
     "loader.js": "^4.7.0",
     "minimatch": "^3.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Dev dependencies is the wrong area for exposed functionality packages in addons. Moved is-plain-object to main dependencies. 