### PR TITLE
Add info text

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -18,7 +18,9 @@
     ...attributes
     data-test-field-for={{this._testingSelector}}
   >
-    <LabelFor @label={{@label}} @controlId={{this.controlId}} />
+    {{#unless this.hideDefaultLabel}}
+      <LabelFor @label={{@label}} @controlId={{this.controlId}} @infoText={{this.infoText}}/>
+    {{/unless}}
     {{#if this._showValue}}
       {{#if this.displayValueComponent}}
         {{component
@@ -152,6 +154,13 @@
                     doSubmit=this.doSubmit
                     doReset=this.doReset
                     onChange=this.handleChange
+                  )
+                  label=(component
+                    'label-for'
+                    label=label
+                    controlId=controlId
+                    infoText=infoText
+                    field=this
                   )
                   self=this
                 )

--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -6,12 +6,11 @@ import { oneWay, notEmpty, gt, union, readOnly } from '@ember/object/computed';
 import { dasherize } from '@ember/string';
 import { isArray } from '@ember/array';
 import { action, defineProperty, computed } from '@ember/object';
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import { later } from '@ember/runloop';
 import { isBlank } from '@ember/utils';
 import { inject as service } from '@ember/service';
-import { deprecate } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { isPlainObject } from 'is-plain-object';
 
@@ -88,6 +87,8 @@ export default class FieldForComponent extends Component {
   @tracked isEditing = false;
 
   @tracked controlShouldStoreAsPrimitive = false;
+
+  @tracked hideDefaultLabel = false;
 
   // --------------------------------------------------------------------------------
   // Computed Properties
@@ -358,13 +359,23 @@ export default class FieldForComponent extends Component {
 
   /**
    * The label for this field
-   * @property field
+   * @property infoText
    * @type String
    * @default null
    * @public
    */
   @arg(string)
   label = null;
+
+  /**
+   * The info-text for this field
+   * @property infoText
+   * @type String
+   * @default null
+   * @public
+   */
+  @arg(string)
+  infoText = null;
 
   /**
    * Generated ID to tie together the label and the control
@@ -533,6 +544,16 @@ export default class FieldForComponent extends Component {
    */
   @arg(string)
   displayValueComponent = null;
+
+  /**
+   * Custom Label Component for rendering the label on this field
+   * @property customLabelComponent
+   * @type String
+   * @default null
+   * @public
+   */
+  @arg(string)
+  customLabelComponent;
 
   /**
    * Function for formatting the value override for custom behavior

--- a/addon/components/form-for.hbs
+++ b/addon/components/form-for.hbs
@@ -28,6 +28,7 @@
           hasControlCallout=this.hasControlCallout
           fieldForControlCalloutClasses=this.fieldForControlCalloutClasses
           fieldClasses=this.fieldClasses
+          customLabelComponent=this._customLabelComponent
         )
         fieldFor=(component
           "field-for"

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -93,6 +93,21 @@ export default class FormForComponent extends Component {
   @readOnly('formFor.customCommitCancelComponent') customCommitCancelComponent;
   @readOnly('formFor.customErrorComponent') customErrorComponent;
 
+
+  /**
+   * Custom Label Component for rendering all labels on this form
+   * @property customLabelComponent
+   * @type String
+   * @default null
+   * @public
+   */
+  @arg(string)
+  customLabelComponent;
+
+  get _customLabelComponent() {
+    return this.customLabelComponent || this.formFor.customLabelComponent;
+  }
+
   get isDirty() {
     return (this.useEmberDataDirtyTracking && this.model?.hasDirtyAttributes) || this.isModelDirty;
   }

--- a/addon/components/label-for.hbs
+++ b/addon/components/label-for.hbs
@@ -1,5 +1,28 @@
 {{#if @label}}
-  <label for="{{@controlId}}" ...attributes>
-    {{@label}}
-  </label>
+  {{#if this.customLabelComponent}}
+    {{component
+      this.customLabelComponent
+      for=@controlId
+      label=@label
+    }}
+  {{else}}
+    <label for="{{@controlId}}" ...attributes>
+      {{#if (hasBlock)}}
+        {{yield controlId}}
+      {{else}}
+        {{@label}}
+      {{/if}}
+
+      {{#if @infoText}}
+        {{#if this.form.customInfoTextComponent}}
+          {{component
+            this.form.customInfoTextComponent
+            infoText=@infoText
+          }}
+        {{else}}
+          <span title="{{@infoText}}">ℹ️</span>
+        {{/if}}
+      {{/if}}
+    </label>
+  {{/if}}
 {{/if}}

--- a/addon/components/label-for.js
+++ b/addon/components/label-for.js
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { arg } from 'ember-arg-types';
+import { object, string} from 'prop-types';
+import { next } from '@ember/runloop';
+
+
+export default class LabelFor extends Component {
+  @service formFor;
+
+  /**
+   * Custom Label Component for rendering all labels on this form
+   * @property customLabelComponent
+   * @type String
+   * @default null
+   * @public
+   */
+  @arg(string)
+  customLabelComponent;
+
+  @arg(object)
+  field;
+
+  constructor() {
+    super(...arguments);
+
+    if (this.field) {
+      next(() => this.field.hideDefaultLabel = true)
+    }
+  }
+
+}

--- a/addon/services/form-for.js
+++ b/addon/services/form-for.js
@@ -25,6 +25,8 @@ export default class FormForService extends Service {
     this.customCommitCancelComponent = this.config.customCommitCancelComponent;
     this.customErrorComponent = this.config.customErrorComponent;
     this.customButtonComponent = this.config.customButtonComponent;
+    this.customLabelComponent = this.config.customLabelComponent;
+    this.customInfoTextComponent = this.config.customInfoTextComponent;
     this.preventsNavigationByDefault = this.config.preventsNavigationByDefault;
 
     this.router.on('routeWillChange', (transition) => {

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,8 @@ module.exports = function (/* environment, appConfig */) {
         customCommitCancelComponent: null,
         customErrorComponent: null,
         customButtonComponent: null,
+        customLabelComponent: null,
+        customInfoTextComponent: null,
 
         controlsFolder: 'form-controls',
         controlPrefix: 'ff-',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ember-element-helper": "^0.3.1",
         "ember-event-helpers": "^0.1.1",
         "is-plain-object": "^5.0.0",
+        "prop-types": "^15.7.2",
         "webpack": "^5.66.0"
       },
       "devDependencies": {
@@ -64,7 +65,6 @@
         "minimatch": "^3.0.4",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.1.2",
-        "prop-types": "^15.7.2",
         "qunit-dom": "^1.5.0",
         "sinon": "^9.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-element-helper": "^0.3.1",
     "ember-event-helpers": "^0.1.1",
     "is-plain-object": "^5.0.0",
+    "prop-types": "^15.7.2",
     "webpack": "^5.66.0"
   },
   "devDependencies": {
@@ -82,7 +83,6 @@
     "minimatch": "^3.0.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",
-    "prop-types": "^15.7.2",
     "qunit-dom": "^1.5.0",
     "sinon": "^9.2.1"
   },

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -42,7 +42,7 @@ The various features can be toggled on / off below.
         <h2 class="docs-md__h2">Form</h2>
         <div class="columns">
           <div>
-            <form.field @for="string" @using="input" @label="String" @valueTooltip="An String" @editText='Click to edit'/>
+            <form.field @for="string" @using="input" @label="String" @valueTooltip="An String" @editText='Click to edit' @infoText='A String'/>
             <form.field @for="password" @using="password" @label="Password" @valueTooltip="An Password" />
             <form.field @for="text" @using="textarea" @label="Text" @valueTooltip="An Text"/>
             <form.field @for="email" @using="email" @label="Email" @valueTooltip="An Email"/>
@@ -148,7 +148,7 @@ The various features can be toggled on / off below.
         </form.field>
         <div class="columns">
           <div>
-            <form.field @for="enableSubmit" @using="checkbox" class="push-right" as |f|>
+            <form.field @for="enableSubmit" @label='hi' @using="checkbox" class="push-right" as |f|>
               <f.control @label="willSubmit" />
             </form.field>
             <form.field 


### PR DESCRIPTION
This commit adds info text to the label component with a default
implementation that uses title.

It also allows you to provide your own label component to render
tooltips as you please.