### PR TITLE
Ensure lazy instant. of callout for inline fields

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -62,7 +62,7 @@
         </button>
       {{/if}}
     {{/if}}
-    {{#if this.hasControlCallout}}
+    {{#if (and this.hasControlCallout this._showControl)}}
       <AttachPopover
         @id={{this.guid}}
         @isShown={{this._showControl}}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",
     "ember-arg-types": "^0.2.1",
-    "ember-attacher": "1.1.1",
+    "ember-attacher": "1.3.0",
     "ember-auto-import": "^1.12.1",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.3.1",


### PR DESCRIPTION
* Previously, all fields on an inline edit form with callouts would fully render each callout which was a huge performance hit