### PR TITLE
Allow numbers as values for comparison in select

### DIFF
--- a/addon/components/form-controls/abstract-select.js
+++ b/addon/components/form-controls/abstract-select.js
@@ -60,7 +60,7 @@ export default class FormControlsAbstractSelectComponent extends Component {
   }
 
   _compare(a, b) {
-    return this.coerceValue(a) === this.coerceValue(b);
+    return this.coerceValue(a) == this.coerceValue(b);
   }
 
   /** Borrowed from https://github.com/jonschlinkert/is-primitive */


### PR DESCRIPTION
Allows numbers to be used as a primitive value for abstract select