### PR TITLE
Add scroll to visible first visible error

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -17,6 +17,7 @@
     {{on "change" (stop-propagation)}}
     ...attributes
     data-test-field-for={{this._testingSelector}}
+    {{did-insert this.registerElement}}
   >
     {{#unless this.hideDefaultLabel}}
       <LabelFor @label={{@label}} @controlId={{this.controlId}} @infoText={{this.infoText}} />

--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -221,6 +221,7 @@ export default class FieldForComponent extends Component {
   get _valueIsDirty() {
     return this._stringify(this._lastValidValue) !== this._stringify(this.value);
   }
+
   get _valueIsNotBlank() {
     return !isBlank(this._lastValidValue) || !isBlank(this.value);
   }
@@ -261,6 +262,34 @@ export default class FieldForComponent extends Component {
 
   get propertyPath() {
     return this.params.join(',');
+  }
+
+  element;
+
+  /**
+   * Options to pass to the field scroll into view
+   * @property scrollIntoViewOptions
+   * @type object
+   * @private
+   */
+  @arg(object)
+  scrollIntoViewOptions = { behavior: 'smooth' };
+
+  /**
+   *
+   * Scrolls this element to visibile
+   *
+   * @method scrollToVisible
+   */
+  scrollToVisible() {
+    this.element.scrollIntoView(
+      this.scrollIntoViewOptions ?? this.form.scrollIntoViewOptions ?? {}
+    );
+  }
+
+  @action
+  registerElement(el) {
+    this.element = el;
   }
 
   /**
@@ -307,6 +336,7 @@ export default class FieldForComponent extends Component {
       return JSON.stringify(value);
     }
   }
+
   _extractKeyValueMapping(_value) {
     const params = this.params;
     const _withMapping = this.args.withMapping || {};
@@ -343,6 +373,7 @@ export default class FieldForComponent extends Component {
 
   willDestroy() {
     this.args.form.deregisterField(this);
+    this.element = null;
   }
 
   // --------------------------------------------------------------------------------

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -239,6 +239,26 @@ export default class FormForComponent extends Component {
   readonly = false;
 
   /**
+   * When an error is detected on the form, if this is set to true, scroll to failed field to
+   * visible
+   * @property scrollToFirstVisibleError
+   * @type boolean
+   * @default false
+   * @public
+   */
+  @arg(bool)
+  scrollToFirstVisibleError = false;
+
+  /**
+   * Options to pass to the field scroll into view
+   * @property scrollIntoViewOptions
+   * @type object
+   * @private
+   */
+  @arg(object)
+  scrollIntoViewOptions;
+
+  /**
    * Whether or not this form is setup for inline editing
    * @property inlineEditing
    * @type boolean
@@ -804,6 +824,12 @@ export default class FormForComponent extends Component {
       return doSubmit;
       // somehow we set out selves to the last do submit?
     } else {
+      if (!willSubmit && this.scrollToFirstVisibleError) {
+        // Find field with error and scroll to visible
+        const firstBadField = this.fields.find((_) => _.hasErrors);
+        firstBadField.scrollToVisible();
+      }
+
       this._hasFailedToSubmit = true;
       this.didNotSubmit(model);
       this.notifyError(this.didNotSubmitMessage);

--- a/addon/services/form-for.js
+++ b/addon/services/form-for.js
@@ -31,6 +31,7 @@ export default class FormForService extends Service {
 
     this.router.on('routeWillChange', (transition) => {
       if (
+        !transition.isAborted &&
         this.shouldPreventNavigation &&
         !confirm('You have unsaved changes, are you sure you want to leave?')
       ) {

--- a/tests/dummy/app/controllers/docs/usage.js
+++ b/tests/dummy/app/controllers/docs/usage.js
@@ -34,6 +34,9 @@ export default class UsageController extends Controller {
   @tracked
   errors = false;
 
+  @tracked
+  scrollToVisible = false;
+
   @action
   toggleErrors() {
     if (this.errors) {

--- a/tests/dummy/app/templates/docs/forms.md
+++ b/tests/dummy/app/templates/docs/forms.md
@@ -127,6 +127,14 @@ Forms can be configured to notify the user when a form either succeeds or fails.
 
 The form-for service can be extended to provide custom popups, or messages by injecting it into your application.
 
+## Errors
+
+By default ember-foxy-forms wires errors from ember-data models. 
+
+
+### scrollToFirstVisibleError
+
+You can configure a form to scroll its first field with an error into view on failed submission. Using the scrollToFirstVisibleError options.
 
 ## Navigation Guards
 

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -15,6 +15,7 @@ The various features can be toggled on / off below.
         @inlineEditing={{this.inline}} 
         @hasControlCallout={{this.hasControlCallout}} 
         @autoSubmit={{this.autoSubmit}} 
+        @scrollToFirstVisibleError={{this.scrollToFirstVisibleError}}
         
         @successfulSubmitMessage={{this.successfulSubmitMessage}}
         @failedSubmitMessage={{this.failedSubmitMessage}}
@@ -129,6 +130,12 @@ The various features can be toggled on / off below.
           @didCommitValue={{this.toggleErrors}}
         as |f|>
           <f.control @label="Errors" />
+        </form.field>
+        <form.field 
+          @for="scrollToFirstVisibleError" 
+          @using="checkbox" 
+        as |f|>
+          <f.control @label="Scroll To Visible Error" />
         </form.field>
         <form.field @for="preventsNavigation" @using="checkbox" as |f|>
           <f.control @label="Prevents Navigation" />


### PR DESCRIPTION
This commit adds the ability for a Form to be configured to scroll to
the first error.

It also fixes an issue with the service that would be get stuck in an
infinite loop when aborting a dirty transition.