### PR TITLE
Fix ff-input readonly bug

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -86,8 +86,8 @@
                     values=(readonly this._values)
                     errors=(readonly this.errors)
                     placeholder=this.placeholder
-                    readonly=@readonly
-                    disabled=@disabled
+                    readonly=this.readonly
+                    disabled=this.disabled
                     required=this.required
                     controlId=this.controlId
                     storeAsPrimitive=this.controlShouldStoreAsPrimitive
@@ -106,9 +106,9 @@
                 value=(readonly this._value)
                 values=(readonly this._values)
                 errors=(readonly this.errors)
-                placeholder=@placeholder
-                readonly=@readonly
-                disabled=@disabled
+                placeholder=this.placeholder
+                readonly=this.readonly
+                disabled=this.disabled
                 required=this.required
                 controlId=this.controlId
                 storeAsPrimitive=this.controlShouldStoreAsPrimitive
@@ -148,8 +148,8 @@
                     values=(readonly this._values)
                     errors=(readonly this.errors)
                     placeholder=this.placeholder
-                    readonly=@readonly
-                    disabled=@disabled
+                    readonly=this.readonly
+                    disabled=this.disabled
                     required=this.required
                     controlId=this.controlId
                     storeAsPrimitive=this.controlShouldStoreAsPrimitive
@@ -175,9 +175,9 @@
                 value=(readonly this._value)
                 values=(readonly this._values)
                 errors=(readonly this.errors)
-                placeholder=@placeholder
-                readonly=@readonly
-                disabled=@disabled
+                placeholder=this.placeholder
+                readonly=this.readonly
+                disabled=this.disabled
                 required=this.required
                 controlId=this.controlId
                 storeAsPrimitive=this.controlShouldStoreAsPrimitive

--- a/addon/components/form-controls/ff-currency.hbs
+++ b/addon/components/form-controls/ff-currency.hbs
@@ -5,7 +5,7 @@
   @update={{this.handleChange}}
   id={{@controlId}}
   disabled={{@disabled}}
-  readonly={{@isReadonly}}
+  readonly={{@readonly}}
   ...attributes
   data-test-ff-control-currency
   {{on "blur" this.handleBlur}}

--- a/addon/components/form-controls/ff-input.hbs
+++ b/addon/components/form-controls/ff-input.hbs
@@ -4,7 +4,7 @@
   type={{this.inputType}}
   placeholder={{@placeholder}}
   disabled={{@disabled}}
-  readonly={{@readonly}}
+  readonly={{this.readonly}}
   required={{@required}}
   aria-required={{@required}}
   maxlength={{@maxLength}}

--- a/addon/components/form-controls/ff-input.js
+++ b/addon/components/form-controls/ff-input.js
@@ -7,7 +7,7 @@ export default class FormControlsFfInputComponent extends Component {
   live = false;
 
   @arg(bool)
-  readonly = true;
+  readonly = false;
 
   @arg(string)
   inputType = 'text';

--- a/addon/components/form-controls/ff-multiple-input.hbs
+++ b/addon/components/form-controls/ff-multiple-input.hbs
@@ -4,6 +4,7 @@
     type="text"
     value={{get @value item.key}}
     disabled={{@disabled}}
+    readonly={{@readonly}}
     ...attributes
     data-test-multiple-input
     {{on "change" (fn this.handleValueChange item.key)}}

--- a/addon/components/form-controls/ff-textarea.hbs
+++ b/addon/components/form-controls/ff-textarea.hbs
@@ -4,7 +4,7 @@
     value={{@value}}
     placeholder={{@placeholder}}
     disabled={{@disabled}}
-    readonly={{@isReadonly}}
+    readonly={{@readonly}}
     maxlength={{this.maxLength}}
     max={{@max}}
     min={{@min}}


### PR DESCRIPTION
## Input field does not have readonly attr but does not take any values
- Now that we removed most of the arguments passed from Form to Field other than `form`, field-for component was updated to use `this.form.something` to access attributes on the form. 
 - Those args were updated to use arg types so that when arg is not provided it would default to `this.form.something || someDefaultValue`
      - e.g. ` @arg(bool) get readonly() { return this.form?.readonly || false; }`
 - However, in the template side, some of the args (`readonly` and `disabled`) were accessed using `@` directly which would result in `undefined` without default value.  And this value is passed to controls.
 - On`ff-input-control` component side, it also uses arg type with a default value of true. So because `undefined` is passed due to reasons above, it would default to true which triggered `preventDefault` on key events preventing values to be committed.
 - Again, `ff-input-control` template also directly used `@readonly` instead of `this.readonly` while using arg types. This resulted in a weird behaviour where **the element does not have readonly attribute while no values are being committed.**
- Also some input controls were using `isReadonly` instead of `readonly`making form unable to make the control readonly.