### PR TITLE
Allow model to reset after destroy

### DIFF
--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -371,21 +371,22 @@ export default class FieldForComponent extends Component {
   /**
    * Resets the field to the backup value by re-committing the value
    * @method _resetField
+   * @params {Object} model Optional model to use, useful for when
    * @private
    */
-  _resetField() {
+  _resetField(model) {
     const form = this.args.form;
 
     if (this._hasCompositeValue) {
       let values = this._extractKeyValueMapping(this._lastValidValue);
-      this.didResetValues(values);
-      form.resetValues(values);
+      this.didResetValues(values, model);
+      form.resetValues(values, model);
     } else {
-      this.didResetValue(this._lastValidValue);
-      form.resetValue(this.params[0], this._lastValidValue);
+      this.didResetValue(this._lastValidValue, model);
+      form.resetValue(this.params[0], this._lastValidValue, model);
     }
 
-    form.clearValidations();
+    form.clearValidations(model);
   }
 
   willDestroy() {
@@ -729,8 +730,8 @@ export default class FieldForComponent extends Component {
    * @public
    */
   @arg(func)
-  formDidReset = () => {
-    this._resetField();
+  formDidReset = (model) => {
+    this._resetField(model);
   };
 
   /**
@@ -788,7 +789,7 @@ export default class FieldForComponent extends Component {
   @action
   cancel() {
     this._value = this.value;
-    this._resetField();
+    this._resetField(this.form.model);
     this.isEditing = false;
   }
 

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -755,8 +755,8 @@ export default class FormForComponent extends Component {
    * @public
    */
   @arg(func)
-  clearValidations = () => {
-    const model = this.model;
+  clearValidations = (model) => {
+    model = model ?? this.model;
     return model.validate && model.validate({ only: [] });
   };
 
@@ -906,10 +906,10 @@ export default class FormForComponent extends Component {
     if (shouldReset) {
       try {
         this.isResetting = true;
-        await this.onReset();
+        await this.onReset(model);
         this.notifySuccess(this.successfulResetMessage);
-        this.didReset();
-        this._runFieldDidReset();
+        this.didReset(model);
+        this._runFieldDidReset(model);
         this._markClean();
       } catch (e) {
         this.notifyError(this.failedResetMessage);
@@ -981,18 +981,18 @@ export default class FormForComponent extends Component {
     });
   }
 
-  resetValues(keyValues) {
-    if (this.model.setProperties) {
-      this.model.setProperties(keyValues);
+  resetValues(keyValues, model) {
+    if (model.setProperties) {
+      model.setProperties(keyValues);
     } else {
-      setProperties(this.model, keyValues);
+      setProperties(model, keyValues);
     }
 
     this._checkClean();
   }
 
-  resetValue(key, value) {
-    this.resetValues({ [key]: value });
+  resetValue(key, value, model) {
+    this.resetValues({ [key]: value }, model);
   }
 
   /**
@@ -1068,8 +1068,8 @@ export default class FormForComponent extends Component {
    * @method _runFieldDidReset
    * @private
    */
-  _runFieldDidReset() {
-    (this.fields || []).forEach((_) => _.formDidReset());
+  _runFieldDidReset(model) {
+    (this.fields || []).forEach((_) => _.formDidReset(model));
   }
 
   /**


### PR DESCRIPTION
* Allows foxy-forms to reset the model even after the component is destroyed.
* Needed for supporting async willReset on destroy