### PR TITLE
Pass form to control components

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -33,7 +33,7 @@
           editText=this.editText
           placeholder=this.placeholder
           field=this
-          form=@form
+          form=this.form
         }}
       {{else}}
         <button
@@ -94,6 +94,7 @@
                     doSubmit=this.doSubmit
                     doReset=this.doReset
                     onChange=this.handleChange
+                    form=this.form
                   )
                   self=this
                 )
@@ -115,6 +116,7 @@
                 doSubmit=this.doSubmit
                 doReset=this.doReset
                 onChange=this.handleChange
+                form=this.form
               }}
             {{/if}}
 
@@ -156,6 +158,7 @@
                     doSubmit=this.doSubmit
                     doReset=this.doReset
                     onChange=this.handleChange
+                    form=this.form
                   )
                   label=(component
                     "label-for"
@@ -184,6 +187,7 @@
                 doSubmit=this.doSubmit
                 doReset=this.doReset
                 onChange=this.handleChange
+                form=this.form
               }}
             {{/if}}
 


### PR DESCRIPTION
Pass form to control so that it can have access to form and do some logics based on the state of form.
- Planning to skip running onChange function on key up in textarea and input when autosubmit is true