### PR TITLE
Add support for boolean values in select

### DIFF
--- a/addon/components/form-controls/ff-select.js
+++ b/addon/components/form-controls/ff-select.js
@@ -19,7 +19,7 @@ export default class FormControlsFfSelectComponent extends FormControlsAbstractS
 
   @action
   handleChange(event) {
-    let value = event.target.value;
+    let value = JSON.parse(event.target.value);
 
     value = this.values.find((_) => this._compare(_, value));
 


### PR DESCRIPTION
- Currently ff-select cannot detect boolean values from event.target.value compared with the provided values (when it has boolean as an option) since value from event.target.value is always a string.
- When stringified boolean is found from event object, make it a boolean