### PR TITLE
JSON parse only if value is stringified boolean

### DIFF
--- a/addon/components/form-controls/ff-select.js
+++ b/addon/components/form-controls/ff-select.js
@@ -19,7 +19,10 @@ export default class FormControlsFfSelectComponent extends FormControlsAbstractS
 
   @action
   handleChange(event) {
-    let value = JSON.parse(event.target.value);
+    let value = event.target.value;
+    if (value === 'true' || value === 'false') {
+      value = JSON.parse(event.target.value);
+    }
 
     value = this.values.find((_) => this._compare(_, value));
 


### PR DESCRIPTION
Running JSON.parse on strings throws error.
only run it if it is stringified boolean