### PR TITLE
Default validationOptions to defined fields

### DIFF
--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -122,6 +122,14 @@ export default class FieldForComponent extends Component {
   @notEmpty('errors') hasErrors;
 
   /**
+   * The property this field controls
+   *
+   * @returns {String}
+   */
+  @arg(string)
+  for = '';
+
+  /**
    * Allowing for overriding existing errors from model
    *
    * @returns {String[]}

--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -478,7 +478,9 @@ export default class FormForComponent extends Component {
    * @public
    */
   @arg(object)
-  validationOptions = {};
+  get validationOptions() {
+    return { only: this.fields.mapBy('for') };
+  }
 
   /**
    * Allows multiple submit calls to be queued
@@ -1197,6 +1199,7 @@ export default class FormForComponent extends Component {
   updateValues(keyValues) {
     return this.updateValuesFn(keyValues);
   }
+
   @action testClass(type) {
     return `${type}-button`;
   }

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -357,7 +357,7 @@ module('Integration | Component | form for', function (hooks) {
         <f.reset/>
         <f.destroy/>
         <f.button/>
-      </FormFor>  
+      </FormFor>
     `);
 
     assert
@@ -379,7 +379,7 @@ module('Integration | Component | form for', function (hooks) {
       <f.reset/>
       <f.destroy/>
       <f.button/>
-    </FormFor>  
+    </FormFor>
   `);
     assert
       .dom('[data-test-form-button="submit"]')
@@ -681,5 +681,26 @@ module('Integration | Component | form for', function (hooks) {
     assert.dom('[data-test-ff-control-input]').hasAttribute('aria-required');
     assert.dom('[data-test-form-button="submit"]').doesNotHaveClass('disabled');
     assert.dom('[data-test-form-button="submit"]').doesNotHaveAttribute('disabled');
+  });
+
+  test('builds its default validation options out of the fields that are registered', async function (assert) {
+    this.model = { foo: null, bar: null };
+
+    this.validationOptions = {};
+
+    this.registerForm = (form, _element) => {
+      this.validationOptions = form.validationOptions;
+    };
+
+    await render(hbs`
+      <Form @for={{this.model}} as |f|>
+        <f.field @for='foo' />
+        <f.submit />
+        <div {{did-insert (action this.registerForm f.self)}} ></div>
+      </Form>
+    `);
+
+    assert.equal(this.validationOptions.only[0], 'foo');
+    assert.equal(this.validationOptions.only.length, 1);
   });
 });


### PR DESCRIPTION
This commit defaults validation options to defined fields to prevent weird errors.