### PR TITLE
add argument for control callout hide/show

### DIFF
--- a/addon/components/field-for.hbs
+++ b/addon/components/field-for.hbs
@@ -76,8 +76,8 @@
       <AttachPopover
         @id={{this.guid}}
         @isShown={{this._showControl}}
-        @showOn=""
-        @hideOn=""
+        @showOn={{this.controlCalloutShowOn}}
+        @hideOn={{this.controlCalloutHideOn}}
         @showDuration="0"
         @hideDuration="0"
         @arrow={{true}}

--- a/addon/components/field-for.js
+++ b/addon/components/field-for.js
@@ -596,6 +596,32 @@ export default class FieldForComponent extends Component {
   }
 
   /**
+   * dom events that should hide popover
+   * inline-edit mode
+   * @property controlCalloutHideOn
+   * @type Boolean
+   * @default "blur escapekey"
+   * @public
+   */
+  @arg(string)
+  get controlCalloutHideOn() {
+    return this.form?.controlCalloutHideOn || 'blur escapekey';
+  }
+
+  /**
+   * dom events that should show popover
+   * inline-edit mode
+   * @property controlCalloutShowOn
+   * @type Boolean
+   * @default ""
+   * @public
+   */
+  @arg(string)
+  get controlCalloutShowOn() {
+    return this.form?.controlCalloutShowOn || '';
+  }
+
+  /**
    * Tooltip to append to the value when inline editing
    * @property valueTooltip
    * @type String


### PR DESCRIPTION
ember attached popover by default has `mouseleave` as an event to hide the callout.
adding an argument so it is configurable and by default do not inlcude mouseleave