### PR TITLE
support validation for array for infields

### DIFF
--- a/addon/components/form-for.js
+++ b/addon/components/form-for.js
@@ -9,6 +9,7 @@ import { A } from '@ember/array';
 import { inject as service } from '@ember/service';
 import { Promise } from 'rsvp';
 import { tracked } from '@glimmer/tracking';
+import { isArray } from '@ember/array';
 
 export default class FormForComponent extends Component {
   @service formFor;
@@ -493,7 +494,7 @@ export default class FormForComponent extends Component {
    */
   @arg(object)
   get validationOptions() {
-    return { only: this.fields.mapBy('for') };
+    return { only: this.fields.mapBy('for')?.flat() };
   }
 
   /**

--- a/tests/integration/components/form-for-test.js
+++ b/tests/integration/components/form-for-test.js
@@ -704,6 +704,28 @@ module('Integration | Component | form for', function (hooks) {
     assert.equal(this.validationOptions.only.length, 1);
   });
 
+  test('builds its default validation options out of the fields that are registered for array fields', async function (assert) {
+    this.model = { foo: null, bar: null };
+
+    this.validationOptions = {};
+
+    this.registerForm = (form, _element) => {
+      this.validationOptions = form.validationOptions;
+    };
+
+    await render(hbs`
+      <Form @for={{this.model}} as |f|>
+        <f.field @for={{array 'foo' 'bar'}} />
+        <f.submit />
+        <div {{did-insert (action this.registerForm f.self)}} ></div>
+      </Form>
+    `);
+
+    assert.equal(this.validationOptions.only[0], 'foo');
+    assert.equal(this.validationOptions.only[1], 'bar');
+    assert.equal(this.validationOptions.only.length, 2);
+  });
+
   test('displays the required text if the form is configured to do so and an attribute is marked required', async function (assert) {
     this.model = { foo: null, bar: null, validations: { foo: { presence: true } } };
 


### PR DESCRIPTION
model-validator does not support validations for fields in arrays .
For example, `{only: ['name', 'email']}` is what it expects.
If it is given an array inside the only array like `{only: ['name',  ['email', 'email-confirmation']]}`, it will skip the validation for the fields in the inner array.

This commit is to make `validationOptions` getter to spread the inner array so that all fields in the array that is provided in `for` to be validated.
